### PR TITLE
At acceptance the improvements was proposed

### DIFF
--- a/src/plib/resources/locales/en-US.php
+++ b/src/plib/resources/locales/en-US.php
@@ -105,6 +105,7 @@ $messages = [
     'controllers.system.stateEnabled' => 'Enabled',
     'controllers.system.stateDisabled' => 'Disabled',
     'controllers.system.stateRunning' => 'Running',
+    'controllers.system.stateInstalled' => 'Installed',
     'controllers.system.stateNotActivated' => 'Not Activated',
     'controllers.system.stateNotInstalled' => 'Not Installed',
     'controllers.system.busy' => 'Please wait...',

--- a/src/plib/views/scripts/index/domain-list.phtml
+++ b/src/plib/views/scripts/index/domain-list.phtml
@@ -108,11 +108,11 @@
 
             if (<?=$this->isSymantecInstalled ? 'false' : 'true'?>) {
                 // Symantec is not installed
+                event.preventDefault();
+                purchaseButton.update('<span class="ajax-loading">' + purchaseButton.textContent + '</span>');
                 $$('div.sw-purchase a').each(function (a) {
                     a.classList.add('disabled');
-                    a.update('<span class="ajax-loading">' + a.textContent + '</span>');
                 });
-                event.preventDefault();
                 new Ajax.Request(<?=$this->jsHtml($this->baseUrl)?> + 'index.php/index/install-symantec', {
                     method: 'post',
                     onSuccess: function () {

--- a/src/plib/views/scripts/index/system.phtml
+++ b/src/plib/views/scripts/index/system.phtml
@@ -264,7 +264,7 @@
                     <td id='secw-symantec-state'>
                         <?php if ($this->isSymantecInstalled && $this->isSymantecActive): ?>
                             <img src="<?=pm_Context::getBaseUrl()?>/images/icon-ready.png" width="30px" height="30px" />
-                            <div class="secw-state-ready"><?=$this->lmsg('controllers.system.stateRunning')?></div>
+                            <div class="secw-state-ready"><?=$this->lmsg('controllers.system.stateInstalled')?></div>
                         <?php elseif ($this->isSymantecInstalled): ?>
                             <img src="<?=pm_Context::getBaseUrl()?>/images/icon-partial.png" width="30px" height="30px" />
                             <div class="secw-state-partial"><?=$this->lmsg('controllers.system.stateNotActivated')?></div>


### PR DESCRIPTION
1. When symantec ssl is not installed, after user press cart-button the spinner appeared in all cart-buttons previously. Now, it appears in pressed button only.
2. On System tab when Symantec SSL is installed the status "Running" appeared previlously. Now, it has been changed to "Installed".